### PR TITLE
precompile restrict for Gray/RGB

### DIFF
--- a/src/ImageUtils.jl
+++ b/src/ImageUtils.jl
@@ -7,4 +7,9 @@ using ImageCore
 
 include("restrict.jl")
 
+if VERSION >= v"1.4.2" # work around https://github.com/JuliaLang/julia/issues/34121
+    include("precompile.jl")
+    _precompile_()
+end
+
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,19 @@
+macro warnpcfail(ex::Expr)
+    modl = __module__
+    file = __source__.file === nothing ? "?" : String(__source__.file)
+    line = __source__.line
+    quote
+        $(esc(ex)) || @warn """precompile directive
+     $($(Expr(:quote, ex)))
+ failed. Please report an issue in $($modl) (after checking for duplicates) or remove this directive.""" _file=$file _line=$line
+    end
+end
+
+function _precompile_()
+    for ST in (N0f8, Float32, Float64)
+        for T in (Gray{ST}, RGB{ST})
+            @warnpcfail precompile(restrict, (Vector{T},))
+            @warnpcfail precompile(restrict, (Matrix{T},))
+        end
+    end
+end # _precompile_


### PR DESCRIPTION
These precompilation directives look worth it to me, but given that this is my first try on precompilation, @timholy could you help check it?

```julia
using ImageCore
@time using ImageUtils
# before: 0.001522 seconds (3.53 k allocations: 286.344 KiB, 120.73% compilation time)
# after: 0.029168 seconds (55.53 k allocations: 4.586 MiB, 7.26% compilation time)

img = rand(Gray{Float64}, 16, 16);

out1 = @time restrict(img) # out1 is an OffsetArray
# before: 0.671686 seconds (1.72 M allocations: 96.817 MiB, 19.23% gc time, 99.99% compilation time)
# after: 0.303320 seconds (334.21 k allocations: 19.492 MiB, 14.23% gc time, 99.98% compilation time)

out2 = @time restrict(out1)
# before: 0.049478 seconds (99.81 k allocations: 5.255 MiB, 99.91% compilation time)
# after:  0.050176 seconds (100.23 k allocations: 5.297 MiB, 99.92% compilation time)
```

Previously, I tried to precompile `restrict!` on `OffsetMatrix` because SnoopCompile marked it as a hot spot, but then switched to `Vector` and `Matrix` given that
the precompilation directives look simpler to me.

The script generated by `SnoopCompile.write` is:

```julia
function _precompile_()
    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
    Base.precompile(Tuple{typeof(restrict),Matrix{Gray{N0f8}}})   # time: 0.41591159
    Base.precompile(Tuple{typeof(which(_restrict!,(Any,Any,Any,Tuple{},Any,Tuple{Vararg{AbstractUnitRange, Npost}},)).generator.gen),Any,Any,Any,Any,Any,Any,Any,Any})   # time: 0.011567029
end
```
