### PR TITLE
`restrict`: only return OffsetArray when input is an OffsetArray

### DIFF
--- a/src/ImageUtils.jl
+++ b/src/ImageUtils.jl
@@ -4,7 +4,9 @@ export restrict
 
 using Base.Cartesian: @nloops
 using ImageCore
+using ImageCore.OffsetArrays
 
 include("restrict.jl")
+include("compat.jl")
 
 end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,0 +1,5 @@
+if VERSION < v"1.2"
+    require_one_based_indexing(A...) = !Base.has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
+else
+    const require_one_based_indexing = Base.require_one_based_indexing
+end

--- a/src/restrict.jl
+++ b/src/restrict.jl
@@ -76,9 +76,20 @@ function restrict(A::AbstractArray, region::Dims)
 end
 
 function restrict(A::AbstractArray{T,N}, dim::Integer) where {T,N}
+    require_one_based_indexing(A)
+
+    indsA = axes(A)
+    newinds = ntuple(i->i==dim ? restrict_indices(indsA[dim]) : indsA[i], Val(N))
+    out = Array{restrict_eltype(first(A)), N}(undef, last.(newinds))
+    restrict!(out, A, dim)
+    out
+end
+function restrict(A::OffsetArray{T,N}, dim::Integer) where {T,N}
     indsA = axes(A)
     newinds = map(UnitRange, ntuple(i->i==dim ? restrict_indices(indsA[dim]) : indsA[i], Val(N)))
-    out = similar(Array{restrict_eltype(first(A)), N}, newinds)
+    # This calls OffsetArrays implementation: a type piracy
+    # https://github.com/JuliaArrays/OffsetArrays.jl/issues/87
+    out = similar(A, restrict_eltype(first(A)), newinds)
     restrict!(out, A, dim)
     out
 end


### PR DESCRIPTION
Unless people's code depends on the array container type (e.g., `out.parent`), this isn't a breaking change.

```julia
img = rand(4, 4)
restrict(img)
# master: 1-based OffsetArray
# PR: Array

img = OffsetArray(rand(4, 4), -1, 0)
restrict(img) # behavior not changed
```

Also, add some more tests on the property.