### PR TITLE
fixes fdiff for FixedPoint types

### DIFF
--- a/src/ImageBase.jl
+++ b/src/ImageBase.jl
@@ -26,6 +26,7 @@ using Reexport
 using Base.Cartesian: @nloops
 @reexport using ImageCore
 using ImageCore.OffsetArrays
+using ImageCore.MappedArrays: of_eltype
 
 include("diff.jl")
 include("restrict.jl")

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -53,7 +53,7 @@ julia> fdiff(A, dims=2, boundary=:zero) # fill boundary with zeros
 
 See also [`fdiff!`](@ref) for the in-place version.
 """
-fdiff(A::AbstractArray; kwargs...) = fdiff!(similar(A), A; kwargs...)
+fdiff(A::AbstractArray; kwargs...) = fdiff!(similar(A, maybe_floattype(eltype(A))), A; kwargs...)
 
 """
     fdiff!(dst::AbstractArray, src::AbstractArray; dims::Int, rev=false, boundary=:periodic)
@@ -69,6 +69,7 @@ function fdiff!(dst::AbstractArray, src::AbstractArray;
     N = ndims(src)
     1 <= dims <= N || throw(ArgumentError("dimension $dims out of range (1:$N)"))
 
+    src = of_eltype(maybe_floattype(eltype(dst)), src)
     r = axes(src)
     r0 = ntuple(i -> i == dims ? UnitRange(first(r[i]), last(r[i]) - 1) : UnitRange(r[i]), N)
     r1 = ntuple(i -> i == dims ? UnitRange(first(r[i])+1, last(r[i])) : UnitRange(r[i]), N)
@@ -101,3 +102,7 @@ end
 
 _fdiff_default_dims(A) = nothing
 _fdiff_default_dims(A::AbstractVector) = 1
+
+maybe_floattype(::Type{T}) where T = T
+maybe_floattype(::Type{T}) where T<:FixedPoint = floattype(T)
+maybe_floattype(::Type{CT}) where CT<:Color = base_color_type(CT){maybe_floattype(eltype(CT))}

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -1,4 +1,9 @@
 @testset "fdiff" begin
+    # Base.diff doesn't promote integer to float
+    @test ImageBase.maybe_floattype(Int) == Int
+    @test ImageBase.maybe_floattype(N0f8) == Float32
+    @test ImageBase.maybe_floattype(RGB{N0f8}) == RGB{Float32}
+
     @testset "API" begin
         # fdiff! works the same as fdiff
         mat_in = rand(3, 3, 3)
@@ -71,7 +76,7 @@
                 sz = ntuple(_->5, N)
                 A = rand(sz...)
                 A_out = similar(A)
-                
+
                 for dims = 1:N
                     out_base = diff(A; dims=dims)
                     out = fdiff(A; dims=dims)
@@ -95,5 +100,10 @@
         A_out = fdiff(A, dims=1, rev=true)
         @test axes(A_out) == (0:2, 0:2)
         @test A_out.parent == fdiff(parent(A), dims=1, rev=true)
+    end
+
+    @testset "FixedPoint" begin
+        A = rand(N0f8, 6, 6)
+        @test fdiff(A, dims=1) == fdiff(float.(A), dims=1)
     end
 end


### PR DESCRIPTION
The previous tests are not comprehensive enough to catch `N0f8` arrays. This PR fixes it.