### PR TITLE
WIP: implement varmult_finite

### DIFF
--- a/src/ImageBase.jl
+++ b/src/ImageBase.jl
@@ -10,6 +10,7 @@ export
     maximum_finite,
     meanfinite,
     varfinite,
+    varmult_finite,
     sumfinite
 
 # Introduced in ColorVectorSpace v0.9.3

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,3 +24,7 @@ for (f1, f2) in ((:minc, :min), (:maxc, :max))
         Base.reducedim_init(f, $f2, A, region)
     end
 end
+
+maybe_floattype(::Type{T}) where T = T
+maybe_floattype(::Type{T}) where T<:FixedPoint = floattype(T)
+maybe_floattype(::Type{CT}) where CT<:Color = base_color_type(CT){maybe_floattype(eltype(CT))}

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -4,8 +4,6 @@ using Statistics
 using Test
 
 @testset "Reductions" begin
-    _abs(x::Colorant) = mapreducec(abs, +, 0, x)
-
     @testset "sumfinite, meanfinite, varfinite" begin
         for T in generate_test_types([N0f8, Float32], [Gray, RGB])
             A = rand(T, 5, 5)


### PR DESCRIPTION
The implementation is more delicate than I thought it is; it is not very clean and there might be a lot of type-related issues in the current implementation.

I choose to keep the `varfinite` symbol as it's more convenient to use, if you think we should deprecate it then I can remove it.

Todo: 

- [ ] check the type stability
- [ ] tests are needed