### PR TITLE
CI: fix macOS arch for Apple Silicon runners

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.6'
+          - 'min'
           # - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -30,14 +30,14 @@ jobs:
             arch: x64
           - os: macOS-latest
             version: '1'
-            arch: x64
+            arch: aarch64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -58,6 +58,6 @@ jobs:
         shell: julia --project=. --startup=no --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,12 +18,12 @@ jobs:
         julia-version: [1]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.julia-version }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.cov
 *.jl.mem
 Manifest.toml
+docs/build

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,18 @@ ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
+Aqua = "0.8"
+Documenter = "1"
 ImageCore = "0.10"
+ImageFiltering = "0.7"
+ImageIO = "0.6"
+ImageMagick = "1"
+OffsetArrays = "1"
 Reexport = "0.2, 1"
+StackViews = "0.1"
+Statistics = "1"
+Test = "1"
+TestImages = "1"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageBase"
 uuid = "c817782e-172a-44cc-b673-b171935fbb9e"
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
@@ -9,7 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 [compat]
 ImageCore = "0.10"
 Reexport = "0.2, 1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,7 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ImageBase = "c817782e-172a-44cc-b673-b171935fbb9e"
 ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
+
+[compat]
+Documenter = "1"
+ImageShow = "0.3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,7 @@ format = Documenter.HTML(edit_link = "master",
 makedocs(modules  = [ImageBase, ],
          format   = format,
          sitename = "ImageBase",
+         checkdocs = :exported,
          pages    = ["index.md", "reference.md"])
 
 deploydocs(repo   = "github.com/JuliaImages/ImageBase.jl.git")

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -12,7 +12,7 @@ restrict
 
 ```@autodocs
 Modules = [ImageBase.FiniteDiff]
-order = [:module, :function]
+Order = [:module, :function]
 ```
 
 ## Statistics

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,14 +8,12 @@ include("testutils.jl")
 @testset "ImageBase.jl" begin
     @testset "Project meta quality checks" begin
         if Base.VERSION >= v"1.3"
-            # Not checking compat section for test-only dependencies
             Aqua.test_ambiguities(ImageBase)
             Aqua.test_all(ImageBase;
                 ambiguities=false,
                 project_extras=true,
                 deps_compat=true,
                 stale_deps=true,
-                project_toml_formatting=true
             )
             doctest(ImageBase, manual = false)
         end

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -99,14 +99,12 @@ using Test
             A = rand(T, 5, 5)
             @test @inferred(minimum_finite(A)) == minimum(A)
             @test @inferred(maximum_finite(A)) == maximum(A)
-            @test minimum_finite(A; dims=1) == minimum(A; dims=1)
-            @test maximum_finite(A; dims=1) == maximum(A; dims=1)
-            @test_broken @inferred maximum_finite(A; dims=1)
-            @test_broken @inferred minimum_finite(A; dims=1)
+            @test @inferred(minimum_finite(A; dims=1)) == minimum(A; dims=1)
+            @test @inferred(maximum_finite(A; dims=1)) == maximum(A; dims=1)
 
             @test maximum_finite(abs2, A) == maximum(abs2, A)
-            @test_broken @inferred maximum(abs2, A)
-            @test_broken @inferred minimum(abs2, A)
+            @test @inferred(maximum(abs2, A)) == maximum(abs2, A)
+            @test @inferred(minimum(abs2, A)) == minimum(abs2, A)
 
             if eltype(T) != N0f8
                 A = rand(T, 5, 5) .- 0.5 * rand(T, 5, 5)


### PR DESCRIPTION
`macOS-latest` GitHub runners are now Apple Silicon (arm64). `setup-julia@v3` errors when `arch: x64` is requested on them, so the macOS jobs fail.

This configures the matrix to use the correct native architecture (default per-runner for single-arch matrices; explicit `exclude`/`include` for multi-arch matrices) and bumps `julia-actions/setup-julia` to v3.
